### PR TITLE
fix: :bug: Open a new tab when opening a document on votes-index (#26)

### DIFF
--- a/src/core/templates/votes_index.html
+++ b/src/core/templates/votes_index.html
@@ -28,7 +28,7 @@
         <h6>{% trans "Documents" %}</h6>
         <ul>
             {% for document in vote.document_set.all %}
-            <li><a href="{{document.document.url}}">{{document.name}}</a></li>
+            <li><a href="{{document.document.url}}" target="_blank">{{document.name}}</a></li>
             {% endfor %}
         </ul>
         {% endif %}


### PR DESCRIPTION
The link for documents in votes-index now opens a new tab.